### PR TITLE
clean up to simplify library build/use via gradle

### DIFF
--- a/libmevent/statemachine.h
+++ b/libmevent/statemachine.h
@@ -12,6 +12,7 @@
 
 #include <memory>
 #include <set>
+#include <stdio.h>
 
 /**
  * State machine is defined by nodes and edges.  Consider it

--- a/stats_table.h
+++ b/stats_table.h
@@ -2,7 +2,7 @@
  * @file stats_table.h
  * @author matthewv
  * @date Sept 16, 2020
- * @date Copyright 2012-2014
+ * @date Copyright 2012-present
  *
  * @brief
  */
@@ -10,14 +10,9 @@
 #ifndef STATS_TABLE_H
 #define STATS_TABLE_H
 
-#include "meventmgr.h"
-
 #include "rocksdb/cache.h"
 #include "rocksdb/db.h"
 #include "rocksdb/statistics.h"
-#include "snmp_agent.h"
-#include "val_integer64.h"
-#include "val_string.h"
 
 class StatsTable {
   /****************************************************************
@@ -25,33 +20,29 @@ class StatsTable {
    ****************************************************************/
 public:
 protected:
-  MEventMgrPtr m_Mgr;
-  SnmpAgentPtr m_Agent; //!< snmp manager instance
 
 private:
   /****************************************************************
    *  Member functions
    ****************************************************************/
 public:
-  StatsTable() = delete;
-  StatsTable(bool StartWorker = true);
+  StatsTable();
 
   virtual ~StatsTable();
 
-  bool AddTable(const std::shared_ptr<rocksdb::Statistics> &stats,
-                unsigned TableId, const std::string &name);
+  static StatsTable* NewStatsTable(bool StartWorker = true);
 
-  bool AddTable(const std::shared_ptr<rocksdb::Cache> &cache,
-                unsigned TableId, const std::string &name);
+  virtual bool AddTable(const std::shared_ptr<rocksdb::Statistics> &stats,
+                        unsigned TableId, const std::string &name) = 0;
 
-  bool AddTable(rocksdb::DB * dbase,
-                unsigned TableId, const std::string &name);
+  virtual bool AddTable(const std::shared_ptr<rocksdb::Cache> &cache,
+                        unsigned TableId, const std::string &name) = 0;
+
+  virtual bool AddTable(rocksdb::DB * dbase,
+                        unsigned TableId, const std::string &name) = 0;
 
   /// debug
-  void Dump();
-
-protected:
-  void UpdateTableNameList(unsigned TableId, const std::string &name);
+  virtual void Dump() = 0;
 
 private:
   StatsTable(const StatsTable &);            //!< disabled:  copy operator

--- a/stats_table_impl.h
+++ b/stats_table_impl.h
@@ -1,0 +1,60 @@
+/**
+ * @file stats_table_impl.h
+ * @author matthewv
+ * @date Jan 8, 2023
+ * @date Copyright 2012-2014
+ *
+ * @brief
+ */
+
+#ifndef STATS_TABLE_IMPL_H
+#define STATS_TABLE_IMPL__H
+
+#include "libmevent/meventmgr.h"
+
+#include "rocksdb/cache.h"
+#include "rocksdb/db.h"
+#include "rocksdb/statistics.h"
+#include "snmpagent/snmp_agent.h"
+
+class StatsTableImpl : public StatsTable {
+  /****************************************************************
+   *  Member objects
+   ****************************************************************/
+public:
+protected:
+  MEventMgrPtr m_Mgr;
+  SnmpAgentPtr m_Agent; //!< snmp manager instance
+
+private:
+  /****************************************************************
+   *  Member functions
+   ****************************************************************/
+public:
+  StatsTableImpl() = delete;
+  StatsTableImpl(bool StartWorker = true);
+
+  virtual ~StatsTableImpl();
+
+  bool AddTable(const std::shared_ptr<rocksdb::Statistics> &stats,
+                unsigned TableId, const std::string &name) override;
+
+  bool AddTable(const std::shared_ptr<rocksdb::Cache> &cache,
+                unsigned TableId, const std::string &name) override;
+
+  bool AddTable(rocksdb::DB * dbase,
+                unsigned TableId, const std::string &name) override;
+
+  /// debug
+  void Dump() override;
+
+protected:
+  void UpdateTableNameList(unsigned TableId, const std::string &name);
+
+private:
+  StatsTableImpl(const StatsTableImpl &);            //!< disabled:  copy operator
+  StatsTableImpl &operator=(const StatsTableImpl &); //!< disabled:  assignment operator
+
+}; // StatsTable
+
+#endif // ifndef STATS_TABLE_IMPL_H


### PR DESCRIPTION
bring forward changes to make stats_table.h independent for library type build via gradle.